### PR TITLE
fix: support both environment.js and ember-cli-build.js options/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.2.1
+
+-   fix: support both environment.js and ember-cli-build.js options/config
+
 ### 0.1.1
 
 -   Fixed dependencies to include required dependencies for apps/consumers

--- a/README.md
+++ b/README.md
@@ -35,23 +35,39 @@ The `HeroIcon` component supports the following arguments:
 
 By default, all icons for all types will be available within your application. Additionally, the default icon `type`, if not specified, will be `outline`.
 
-If you know you will only be using a subset of icons, then you can greatly reduce the size of your app by customizing the configuration.
+If you know you will only be using a subset of icons, then you can reduce the size of your app by customizing the configuration.
 
-You can customize defaults and available icons by adding a `ember-heroicons` configuration object to your application's `environment.js`. As an example:
+You can customize defaults and available icons by adding a `ember-heroicons` configuration object to your application's `ember-cli-build.js` and `environment.js` files. As an example:
 
 ```javascript
-module.exports = function (environment) {
-    let ENV = {
-        // Add options here
+// ember-cli-build.js
+module.exports = function (defaults) {
+    let app = new EmberApp(defaults, {
+        // instruct ember-heroicons to include/omit specific icons/sets
         "ember-heroicons": {
             // default type to use if not specified to the HeroIcon component
-            defaultType: "mini",
+            defaultType: "outline",
             // omit matching icons (array of string or RegExp)
             omit: [/chevron/, "camera"],
             // include only certain matching icons (array of string or RegExp)
             include: [/.*/],
             // include only certain types (outline, solid, mini)
             types: ["outline"],
+        },
+    });
+    return app.toTree();
+};
+```
+
+```javascript
+// environment.js
+module.exports = function (environment) {
+    let ENV = {
+        // at runtime, if no type is given, you can specify which type to use
+        "ember-heroicons": {
+            // default type to use if not specified to the HeroIcon component
+            // this takes precedence over the value provided in ember-cli-build.js
+            defaultType: "mini",
         },
     };
     // ...

--- a/addon/components/hero-icon.js
+++ b/addon/components/hero-icon.js
@@ -2,11 +2,16 @@ import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import appConfig from 'ember-get-config';
-import { ICONS } from '../utils/heroicons';
+import { DEFAULT_TYPE, ICONS } from '../utils/heroicons';
 
 export default class HeroIconComponent extends Component {
     get type() {
-        return this.args.type || appConfig?.heroicons?.defaultType || 'outline';
+        let type = this.args.type;
+        if (!type) {
+            const config = appConfig ? appConfig['ember-heroicons'] : {};
+            type = config?.defaultType ?? DEFAULT_TYPE ?? 'outline';
+        }
+        return type;
     }
 
     get icon() {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
     name: require('./package').name,
     _nodeModulesPath: null,
     _config: null,
+    _options: null,
 
     included(app) {
         this._super.included.apply(this, arguments);
@@ -25,10 +26,14 @@ module.exports = {
     },
 
     readConfig() {
+        // options are from ember-cli-build.js
+        this._options = this.app.options['ember-heroicons'] || {};
+
+        // config is from environment.js
         const config = this.app.project.config();
         const appConfig = config['ember-heroicons'] || {};
         const configDefaults = {
-            defaultType: 'outline'
+            defaultType: this._options.defaultType ?? 'outline'
         };
         const mergedConfig = Object.assign(configDefaults, appConfig);
         this._config = mergedConfig;
@@ -39,9 +44,9 @@ module.exports = {
 
         const toMatcher = (s) => (s instanceof RegExp ? s : new RegExp(`^${s}$`));
 
-        const omit = (this._config.omit ?? []).map((o) => toMatcher(o));
-        const include = (this._config.include ?? []).map((o) => toMatcher(o));
-        const types = (this._config.types ?? []).map((o) => toMatcher(o));
+        const omit = (this._options.omit ?? []).map((o) => toMatcher(o));
+        const include = (this._options.include ?? []).map((o) => toMatcher(o));
+        const types = (this._options.types ?? []).map((o) => toMatcher(o));
         const icons = glob
             .sync(path.join(heroIconsPath, '**', '*.svg'))
             .map((f) =>
@@ -72,6 +77,7 @@ module.exports = {
                 writeFile(
                     `utils/heroicons.js`,
                     `
+              export const DEFAULT_TYPE = '${this._config.defaultType}';
               export const ICONS = ${JSON.stringify(icons)};
             `
                 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-heroicons",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-heroicons",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@ember/render-modifiers": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-heroicons",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Heroicons for Ember.js",
   "keywords": ["ember-addon", "heroicons", "icons", "tailwind"],
   "repository": "https://github.com/tzellman/ember-heroicons.git",

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -16,8 +16,8 @@
                 role="tab"
                 aria-selected={{eq this.type type.type}}
                 class={{concat
-                    "relative rounded-xl p-6 text-sm leading-6 transition hover:bg-slate-50 cursor-pointer "
-                    (if (eq this.type type.type) "bg-purple-100")
+                    "relative rounded-xl p-6 text-sm leading-6 transition cursor-pointer "
+                    (if (eq this.type type.type) "bg-purple-100 hover:bg-purple-200" "hover:bg-slate-50")
                 }}
                 {{on "click" (fn (mut this.type) type.type)}}
             >
@@ -35,7 +35,7 @@
     {{#if this.icons.length}}
         <dl class="mt-5 grid grid-cols-4 2xl:grid-cols-6 gap-4">
             {{#each this.icons as |icon|}}
-                <div class="overflow-hidden bg-white p-4 shadow">
+                <div class="overflow-hidden bg-white p-4 shadow hover:bg-slate-50">
                     <dt class="flex flex-row items-center space-x-4">
                         <HeroIcon
                             @icon={{icon.name}}


### PR DESCRIPTION
- inclusion options are provided in ember-cli-build.js
- defaultType is provided in ember-cli-build.js and/or environment.js
- updated HeroIcon component to properly set the default type