### PR TITLE
Support Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,10 +52,16 @@ module.exports = {
         const omit = (this._options.omit ?? []).map((o) => toMatcher(o));
         const include = (this._options.include ?? []).map((o) => toMatcher(o));
         const types = (this._options.types ?? []).map((o) => toMatcher(o));
-        const icons = globSync(path.join(heroIconsPath, '**', '*.svg'))
+        // glob always expects path separators to be forward slashes, even on systems where the separator
+        // is a back slash. So we let path.join do what it does, and then we change instances of \ to /.
+        const safeGlobPath = path.join(heroIconsPath, '**', '*.svg').replace(/\\/g, '/');
+        const icons = globSync(safeGlobPath)
             .map((f) =>
                 f
                     .replace(heroIconsPath, '')
+                    // Oddly enough glob return paths with the system separator. So in order to be able
+                    // to split on '/' we have to once again change instances of \ to /
+                    .replace(/\\/g, '/')
                     .split('/')
                     .filter((f) => f)
             )

--- a/tests/integration/components/hero-icon-test.js
+++ b/tests/integration/components/hero-icon-test.js
@@ -9,5 +9,6 @@ module('Integration | Component | hero-icon', function (hooks) {
     test('it renders', async function (assert) {
         await render(hbs`<HeroIcon @icon="film"/>`);
         assert.dom('svg').exists();
+        assert.dom('path').exists();
     });
 });


### PR DESCRIPTION
Fixes #10 

The `glob` package doesn't work with paths that contain back slashes as separators. So to get the icons list to populate properly on Windows we need to convert back slashes to forward slashes before passing the path to `globSync`.

From the `glob` [README](https://github.com/isaacs/node-glob?tab=readme-ov-file#windows)

>Please only use forward-slashes in glob expressions.
>
>Though windows uses either / or \ as its path separator, only / characters are used by this glob implementation. You must use forward-slashes only in glob expressions. Back-slashes will always be interpreted as escape characters, not path separators.