### PR TITLE
fix: Make heroicons a peerdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "ember-source": "^4.8.3 || >= 5.0.0"
+    "ember-source": "^4.8.3 || >= 5.0.0",
+    "heroicons": "^2.1.3"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
- Fixes #5
- Well it does not _fix_ it, but at least it will give the user hint during `pnpm install` that there is something missing